### PR TITLE
CPTF-35 - allow hash with symbol keys in setter

### DIFF
--- a/lib/weighable/model.rb
+++ b/lib/weighable/model.rb
@@ -13,6 +13,7 @@ module Weighable
 
       def define_setter(column, store_as: :gram, precision: nil)
         define_method "#{column}=" do |weight|
+          weight = weight.with_indifferent_access if weight.respond_to?(:with_indifferent_access)
           if weight.respond_to?(:key?) && weight.key?('value') && weight.key?('unit')
             weight = Weight.new(weight['value'], weight['unit'])
           end

--- a/lib/weighable/model.rb
+++ b/lib/weighable/model.rb
@@ -13,9 +13,12 @@ module Weighable
 
       def define_setter(column, store_as: :gram, precision: nil)
         define_method "#{column}=" do |weight|
-          weight = weight.with_indifferent_access if weight.respond_to?(:with_indifferent_access)
-          if weight.respond_to?(:key?) && weight.key?('value') && weight.key?('unit')
-            weight = Weight.new(weight['value'], weight['unit'])
+          if weight.respond_to?(:key?)
+            if weight.key?('value') && weight.key?('unit')
+              weight = Weight.new(weight['value'], weight['unit'])
+            elsif weight.key?(:value) && weight.key?(:unit)
+              weight = Weight.new(weight[:value], weight[:unit])
+            end
           end
           original_unit = weight.try(:unit)
 

--- a/lib/weighable/version.rb
+++ b/lib/weighable/version.rb
@@ -1,3 +1,3 @@
 module Weighable
-  VERSION = '1.4.0'.freeze
+  VERSION = '1.5.0'.freeze
 end

--- a/spec/weighable/model_spec.rb
+++ b/spec/weighable/model_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'weighable/core_ext'
+require 'rails'
+require 'active_model'
+require 'weighable/model'
+
+class Concerned
+  include ActiveModel::Model
+  include Weighable::Model
+
+  # these are stubs for what's done via rails migration
+  attr_accessor :quantity_value, :quantity_unit, :quantity_display_unit
+
+  weighable :quantity, store_as: :gram, presence: true
+end
+
+describe Weighable::Model do
+  describe '.weighable' do
+    subject(:instance) { Concerned.new }
+
+    it 'adds a setter accepting a hash with symbol keys' do
+      instance.quantity = { value: 1, unit: 0 }
+      expect(instance.quantity).to eq(Weighable::Weight.new(1, :gram))
+    end
+
+    it 'adds a setter accepting a hash with string keys' do
+      instance.quantity = { 'value' => 8, 'unit' => 4 }
+      expect(instance.quantity).to eq(Weighable::Weight.new(8, :kilogram))
+    end
+
+    it 'adds a setter accepting a hash with indifferent access' do
+      instance.quantity = { 'value': 33, 'unit': 2 }
+      expect(instance.quantity).to eq(Weighable::Weight.new(33, :pound))
+    end
+  end
+end

--- a/weighable.gemspec
+++ b/weighable.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '> 4.2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'rails', '~> 5.0.7.2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.49.0'
   spec.add_development_dependency 'rspec', '~> 3.4.0'


### PR DESCRIPTION
This allows us to use:
```
weighable_model_instance.weight = { value: 10, unit: 5 }
```
right now for some reason we can only:
```
weighable_model_instance.weight = { 'value' => 10, 'unit' => 5 }
```
on the Ruby upgrade branch (`CPTF-35/upgrade-ruby-to-2.6.1`). Because of that, [this](https://github.com/greenbits/herer-api/blob/release/db/fixtures/qa.rb#L5-L13) fails:

```
be rails db:drop db:create db:schema:load db:seed_fu FILTER=qa
```