### PR TITLE
Optimize comparison if value other is zero

### DIFF
--- a/lib/weighable/version.rb
+++ b/lib/weighable/version.rb
@@ -1,3 +1,3 @@
 module Weighable
-  VERSION = '1.5.0'.freeze
+  VERSION = '1.6.0'.freeze
 end

--- a/lib/weighable/weight.rb
+++ b/lib/weighable/weight.rb
@@ -195,26 +195,36 @@ module Weighable
     end
 
     def <(other)
+      return @value < other if other == 0
+
       other = other.to(unit_name)
       @value < other.value
     end
 
     def <=(other)
+      return @value <= other if other == 0
+
       other = other.to(unit_name)
       @value <= other.value
     end
 
     def >(other)
+      return @value > other if other == 0
+
       other = other.to(unit_name)
       @value > other.value
     end
 
     def >=(other)
+      return @value >= other if other == 0
+
       other = other.to(unit_name)
       @value >= other.value
     end
 
     def <=>(other)
+      return @value <=> other if other == 0
+
       other = other.to(unit_name)
       @value <=> other.value
     end


### PR DESCRIPTION
Converting zero to other unit won't change anything. Also this change allows weighable to be used with Rails 6.x.